### PR TITLE
Fix search input clearing in e2e tests

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -198,9 +198,9 @@ test.describe('BDC Analytics Application', () => {
       const firstRowText = await tableRows.first().textContent();
       expect(firstRowText?.toLowerCase()).toContain('tech');
     }
-    
+
     // Clear search
-    await searchInput.clear();
+    await searchInput.fill('');
     
     // Open the "Tranche" dropdown using accessible combobox role
     const trancheSelect = page.getByRole('combobox', { name: /Tranche/i });


### PR DESCRIPTION
## Summary
- use `fill('')` instead of deprecated `clear()` to empty the dashboard search field

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6883043cfad8832f825ab65c16e8504d