### PR TITLE
Fix E2E workflow server startup

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,7 +47,10 @@ jobs:
       run: npx playwright install --with-deps
 
     - name: Run E2E tests
-      run: npm run test:e2e
+      run: |
+        npm run dev &
+        npx wait-on http://localhost:5173
+        npm run test:e2e
       env:
         PLAYWRIGHT_BASE_URL: http://localhost:5173
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- ensure `npm run test:e2e` exists
- start the dev server before running Playwright tests and wait until it's ready

## Testing
- `npm test --if-present`

------
https://chatgpt.com/codex/tasks/task_e_688304371888832fa13b244a076ad3e5